### PR TITLE
Dead link fixed for Linear Algebra 101 pdf

### DIFF
--- a/summaries.md
+++ b/summaries.md
@@ -59,7 +59,7 @@ I have received emails sometimes  5 or 10  years after 18.06 was over with stude
 |Recitation and Review Materials 2019|
 |--|
 |[2019 Recitation Materials](https://github.com/mitmath/1806/tree/master/recitation-materials/) Drill down -- these are very useful |
-|[Week 1 2/4 Linear Algebra 101](https://github.com/mitmath/1806/raw/master/recitation-materials/Linear_algebra_101.pdf)|
+|[Week 1 2/4 Linear Algebra 101](https://github.com/mitmath/1806/raw/master/recitation-materials-2019/Linear_algebra_101.pdf)|
 |[Week 2 2/11](https://github.com/mitmath/1806/raw/master/recitation-materials/2020/rec2.pdf) Vector Spaces, Transposes, Inverses, Block matmul|
 | [2019 Week 3 Review](https://github.com/mitmath/1806/raw/master/recitation-materials/wk3session.pdf) Matmul, Orthogonal, Rotation |
 


### PR DESCRIPTION
The link for LinAlg 101 pdf file was dead. Pointed to the right location.