### PR TITLE
Fix typo in Gaussian elimination

### DIFF
--- a/notes/LU-for-real.ipynb
+++ b/notes/LU-for-real.ipynb
@@ -970,7 +970,7 @@
     "1 & 3 & -1 & 1 \\\\\n",
     "3 & 11 & 6 & 35\n",
     "\\end{array}\\right]\n",
-    "\\stackrel{r_2 - \\color{red}{1}r_1}{\\stackrel{r_3 + \\color{red}{3}r_1}{\\longrightarrow}}\n",
+    "\\stackrel{r_2 - \\color{red}{1}r_1}{\\stackrel{r_3 - \\color{red}{3}r_1}{\\longrightarrow}}\n",
     "\\left[\\begin{array}{rrr|r}\n",
     "\\boxed{1} & 3 & 1 & 9 \\\\\n",
     "0 & 0 & -2 & -8 \\\\\n",


### PR DESCRIPTION
This should be a minus:

<img width="991" alt="Screen Shot 2022-02-09 at 6 31 17 PM" src="https://user-images.githubusercontent.com/31325319/153308182-d3fa770a-5899-4970-97b3-c5fb83b72b68.png">
